### PR TITLE
Calendar and Organizations page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,10 +12,10 @@
     <link rel="manifest" href="%PUBLIC_URL%/static/manifest.json" />
     <title>VISION</title>
     <!-- FONTS -->
-    <link href="//db.onlinewebfonts.com/c/490a4d8d3a78b2c0ba5e434c76234790?family=DIN+Alternate" rel="stylesheet" type="text/css"/>
-    <!-- <link rel="preconnect" href="https://fonts.gstatic.com"> -->
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600&d
     <link href="https://cdn.syncfusion.com/ej2/material.css" rel="stylesheet" type="text/css" />
+    <link href="//db.onlinewebfonts.com/c/490a4d8d3a78b2c0ba5e434c76234790?family=DIN+Alternate" rel="stylesheet" type="text/css"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600&d
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/static/logo192.png" />
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <link href="https://cdn.syncfusion.com/ej2/material.css" rel="stylesheet" type="text/css" />
     <link href="//db.onlinewebfonts.com/c/490a4d8d3a78b2c0ba5e434c76234790?family=DIN+Alternate" rel="stylesheet" type="text/css"/>
     <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600&d
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600&d" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/static/logo192.png" />
   </head>
   <body>

--- a/src/App.js
+++ b/src/App.js
@@ -12,13 +12,7 @@ import {
 import About from './components/About';
 import Features from './Features';
 import Contact from './Contact';
-// import GlobalFonts from './fonts/fonts';
 
-/** COMMENT DURING PROD **/
-// const API = 'http://127.0.0.1:8000/api/' //COMMENT DURING PROD
-
-
-/** UNCOMMENT DURING PROD **/ 
 const API = 'http://team-vision-cs178.herokuapp.com/api/'
 
 class App extends React.Component {

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './App.css';
 import  Calendar  from './components/Calendar'
 import  Home  from './components/Home'
-import  Clubs from './components/Clubs'
+import  Organizations from './components/Organizations'
 import {
   BrowserRouter as Router,
   Switch,
@@ -87,7 +87,7 @@ class App extends React.Component {
             <Link to="/calendar">Calendar</Link>
           </li>
           <li>
-            <Link to="/clubs">Clubs</Link>
+            <Link to="/organizations">Organizations</Link>
           </li>
         </ul>
 
@@ -116,8 +116,8 @@ class App extends React.Component {
           <Route path="/calendar">
             <Calendar calendarEvents={this.state.calendarEvents} />
           </Route>
-          <Route path="/clubs">
-            <Clubs action={this.fetchEvents} />
+          <Route path="/organizations">
+            <Organizations action={this.fetchEvents} />
           </Route>
           <Route path="/*" component={NoMatch} />
         </Switch>

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import DataSource from '../mock_data/datasource.json';
-import { Inject,ScheduleComponent,Day, Week, WorkWeek, Month, Agenda} from '@syncfusion/ej2-react-schedule';
+import Navbar from '../components/Navbar';
+import Calendarblock from './Calendarblock'
+
 class Calendar extends React.Component { 
   schData = DataSource.scheduleData
   constructor() {
@@ -10,10 +12,13 @@ class Calendar extends React.Component {
     today = new Date();
 
     render() {
-            return <ScheduleComponent enablePersistence={true} currentView='Month' selectedDate={this.today}
-    eventSettings={{ dataSource: this.props.calendarEvents }}>
-      <Inject services={[Day, Week, WorkWeek, Month, Agenda]} />
-      </ScheduleComponent>
+            return (
+            <div>
+              {/* TODO: Announcements bar */}
+              <Navbar />
+              <Calendarblock />
+          </div>
+            );
     }
 }
 

--- a/src/components/Calendarblock/index.js
+++ b/src/components/Calendarblock/index.js
@@ -26,13 +26,14 @@ class Calendarblock extends React.Component {
     return(
       <Wrapper>
         <LeftGroup>
-          <div className="Calendar" style={{ width: 1000, height: 670, position: 'fixed', bottom: '0' }}>
+          <div>
               <h1> C A L E N D A R </h1>
               <ScheduleComponent enablePersistence={true} currentView='Month' selectedDate={this.today} eventSettings={{ dataSource: this.props.calendarEvents }}>
               <Inject services={[Day, Week, WorkWeek, Month, Agenda]} />
               </ScheduleComponent>
           </div>
         </LeftGroup>
+        <div>
         <RightGroup>
         <h2 style={{ textDecoration: 'underline' }}>O R G A N I Z A T I O N S</h2>
         {/* <Organizations /> */}
@@ -42,6 +43,7 @@ class Calendarblock extends React.Component {
               bgColor="white"
               />
         </RightGroup>
+        </div>
       </Wrapper>
     );
   }

--- a/src/components/Calendarblock/index.js
+++ b/src/components/Calendarblock/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import DownloadButton from '../DownloadButton';
+import { Wrapper } from './styled';
+import { LeftGroup, RightGroup } from './styled';
+import { Inject,ScheduleComponent,Day, Week, WorkWeek, Month, Agenda} from '@syncfusion/ej2-react-schedule';
+
+
+class Calendarblock extends React.Component {
+  // schData = DataSource.scheduleData
+  // constructor() {
+  //   super()
+  //   this.scheduleObj = React.createRef();
+  // }
+  //   today = new Date();
+
+  constructor(props) {
+    super(props);
+    this.state = {value: 'Vision'};
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleChange(event) {
+    this.setState({value: event.target.value});
+  }
+
+  handleSubmit(event) {
+    alert('Select an organization: ' + this.state.value);
+    event.preventDefault();
+  }
+  render() {
+    return(
+      <Wrapper>
+        <LeftGroup>
+          <div className="Calendar" style={{ width: 1100, height: 670, position: 'fixed', bottom: '0' }}>
+              <h1> C A L E N D A R </h1>
+              <ScheduleComponent enablePersistence={true} currentView='Month' selectedDate={this.today} eventSettings={{ dataSource: this.props.calendarEvents }}>
+              <Inject services={[Day, Week, WorkWeek, Month, Agenda]} />
+              </ScheduleComponent>
+          </div>
+        </LeftGroup>
+        <RightGroup>
+        <h2 style={{ textDecoration: 'underline' }}>O R G A N I Z A T I O N S</h2>
+        {/* <Organizations /> */}
+            <br/><br/><br/><br/><br/><br/>
+            <DownloadButton
+              text="Download .ics file"
+              bgColor="white"
+              />
+        </RightGroup>
+      </Wrapper>
+    );
+  }
+}
+
+export default Calendarblock;

--- a/src/components/Calendarblock/index.js
+++ b/src/components/Calendarblock/index.js
@@ -6,13 +6,6 @@ import { Inject,ScheduleComponent,Day, Week, WorkWeek, Month, Agenda} from '@syn
 
 
 class Calendarblock extends React.Component {
-  // schData = DataSource.scheduleData
-  // constructor() {
-  //   super()
-  //   this.scheduleObj = React.createRef();
-  // }
-  //   today = new Date();
-
   constructor(props) {
     super(props);
     this.state = {value: 'Vision'};
@@ -33,7 +26,7 @@ class Calendarblock extends React.Component {
     return(
       <Wrapper>
         <LeftGroup>
-          <div className="Calendar" style={{ width: 1100, height: 670, position: 'fixed', bottom: '0' }}>
+          <div className="Calendar" style={{ width: 1000, height: 670, position: 'fixed', bottom: '0' }}>
               <h1> C A L E N D A R </h1>
               <ScheduleComponent enablePersistence={true} currentView='Month' selectedDate={this.today} eventSettings={{ dataSource: this.props.calendarEvents }}>
               <Inject services={[Day, Week, WorkWeek, Month, Agenda]} />

--- a/src/components/Calendarblock/styled.js
+++ b/src/components/Calendarblock/styled.js
@@ -10,13 +10,12 @@ export const Wrapper = styled.div`
 `;
 
 export const LeftGroup = styled.div`
-  width: 300px;
+  width: 65%;
   padding: 50px;
   margin: 0px 50px 75px 10px;
 `;
 
 export const RightGroup = styled.div`
-  width: 310px;
   padding: 50px;
-  margin: -160px 50px 75px 1350px;
+  margin: -600px 50px 75px 1350px;
 `;

--- a/src/components/Calendarblock/styled.js
+++ b/src/components/Calendarblock/styled.js
@@ -10,7 +10,7 @@ export const Wrapper = styled.div`
 `;
 
 export const LeftGroup = styled.div`
-  width: 320px;
+  width: 300px;
   padding: 50px;
   margin: 0px 50px 75px 10px;
 `;

--- a/src/components/Calendarblock/styled.js
+++ b/src/components/Calendarblock/styled.js
@@ -4,8 +4,6 @@ import styled from 'styled-components';
 export const Wrapper = styled.div`
   width: 100%;
   height: 550px;
-  display: flex;
-  flex-direction: column;
   align-items: right;
 `;
 
@@ -13,6 +11,8 @@ export const LeftGroup = styled.div`
   width: 65%;
   padding: 50px;
   margin: 0px 50px 75px 10px;
+  overflow-y: auto;
+  height: 500px;
 `;
 
 export const RightGroup = styled.div`

--- a/src/components/Calendarblock/styled.js
+++ b/src/components/Calendarblock/styled.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 550px;
+  display: flex;
+  flex-direction: column;
+  align-items: right;
+`;
+
+export const LeftGroup = styled.div`
+  width: 320px;
+  padding: 50px;
+  margin: 0px 50px 75px 10px;
+`;
+
+export const RightGroup = styled.div`
+  width: 310px;
+  padding: 50px;
+  margin: -160px 50px 75px 1350px;
+`;

--- a/src/components/DownloadButton/index.js
+++ b/src/components/DownloadButton/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Button } from './styled';
+
+/*
+Functional Componet
+- no explicit state
+- no render function, just the return()
+- uses hooks to manage state (setState)/ lifecycle methods (useEffect)
+*/
+
+// yarn add styled-components
+const DownloadButton = ({ text, fontColor, bgColor, padding, borderRadius }) => {
+  return (
+    <>
+    {/* <TopText>HELLO</TopText> */}
+    <Button fontColor={fontColor} bgColor={bgColor} padding={padding} borderRadius={borderRadius}>
+      {text}
+    </Button>
+    {/* <button style={{ color: "blue", height: "200px", width: "500px" }}></button> */}
+    </>
+  );
+};
+
+export default DownloadButton;

--- a/src/components/DownloadButton/styled.js
+++ b/src/components/DownloadButton/styled.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { fontColor } from '../Colors';
+
+export const Button = styled.button`
+    color: ${props => props.fontColor || "blue"};
+    background-Color: ${props => props.bgColor || "red" };
+    border: 1px solid ${fontColor.Blue};
+    font-size: 16px;
+    min-height: 15px;
+    min-width: 300px;
+    padding: ${props => props.padding || '20px' };
+    border-radius: ${props => props.borderRadius || '50px'};
+`;
+
+// destructing --> exporting someting only using {}
+// export const TopText = styled.h1`
+//  font-size: 20px;
+// `;

--- a/src/components/Organizationblock/index.js
+++ b/src/components/Organizationblock/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { LeftGroup } from './styled';
 
 /** COMMENT DURING PROD **/
 // const API = 'http://127.0.0.1:8000/api/' //COMMENT DURING PROD
@@ -7,7 +8,7 @@ import React from 'react'
 /** UNCOMMENT DURING PROD **/ 
 const API = 'http://team-vision-cs178.herokuapp.com/api/'
 
-class Clubs extends React.Component {
+class OrganizationsBlock extends React.Component {
     state = {
         "ACM" : false,
         "Persian Club" : false,
@@ -42,8 +43,10 @@ class Clubs extends React.Component {
 
     render() {
         return (
-            <div className="Clubs">
+            <LeftGroup>
+            <div style={{ width: '110%',  bottom: '10' }}>
             <form>
+                <h1>O R G A N I Z A T I O N S</h1>
                 <label>
                 Chess Club
                 <input type="checkbox" name="Chess Club" onClick={this.handleClick}/>
@@ -55,12 +58,30 @@ class Clubs extends React.Component {
                 <label>
                 Persian Club
                 <input type="checkbox" name="Persian Club" onClick={this.handleClick}/>
-                </label>                
+                </label><br />
+                <label>
+                Team Vision
+                <input type="checkbox" name="Team Vision" onClick={this.handleClick}/>
+                </label><br />
+                <label>
+                Team Rocket
+                <input type="checkbox" name="Team Rocket" onClick={this.handleClick}/>
+                </label><br />
+                <label>
+                Lakers Fan Club
+                <input type="checkbox" name="Lakers Fan Club" onClick={this.handleClick}/>
+                </label><br />
+                <label>
+                CS178 Fan Club
+                <input type="checkbox" name="CS178 Fan Club" onClick={this.handleClick}/>
+                </label> <br /> <br />                   
             </form>
                 <button onClick={this.handleSubmit}>Submit</button>
              </div>
-        )
+            </LeftGroup>
+
+        );
     }
 }
 
-export default Clubs;
+export default OrganizationsBlock;

--- a/src/components/Organizationblock/styled.js
+++ b/src/components/Organizationblock/styled.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const LeftGroup = styled.div`
+  width: 400px;
+  padding: 50px;
+  margin: 0px 50px 75px 10px;
+`;
+
+// TODO; stick to the bottom of the page
+// border: 2px dotted black;

--- a/src/components/Organizations.js
+++ b/src/components/Organizations.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Navbar from '../components/Navbar';
+import Organizationblock from './Organizationblock'
+
+/** COMMENT DURING PROD **/
+// const API = 'http://127.0.0.1:8000/api/' //COMMENT DURING PROD
+
+
+/** UNCOMMENT DURING PROD **/ 
+
+class Organizations extends React.Component {
+
+
+    render() {
+        return (
+            <div>
+            <Navbar />
+            <Organizationblock />
+             </div>
+        )
+    }
+}
+
+export default Organizations;


### PR DESCRIPTION
Styled the calendar page in order to create a better and cleaner look to the page. Added organization label towards the right hand side of the page along with "Download .ics file" button under it. The button is intended to extract data from the listed organizations, and display it accordingly onto the calendar. This will be configured properly next quarter. The calendar should allow the user to create/add/delete their own events, and I preloaded events into the calendar already using a JSON file. Also made some alignment changes to the organizations page. I took the time to reorganize the code for the calendar and organizations page in order to make it simpler to implement new features for the next milestone. Rather than everything being clustered on two files, I spread out the code into specific files corresponding with what the code is intended for. Also added scroll feature to calendar in order to avoid the contents on the right side of the calendar page from moving vertically.