### PR TITLE
Added multiple functionalities

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -32,7 +32,9 @@ urlpatterns = [
     path('api/deleteOrganization', views.deleteOrganization),
     path('api/createOrganization', views.createOrganization),
     path('api/createEvent', views.createEvent),
+    path('api/blockUsers', views.blockUsers),
     path('api/getListOfOrganizations',views.getListOfOrganizations),
+    path('api/getDictionaryOfMembers', views.getDictionaryOfMembers),
     path('api/public',views.public),
     path('api/private',views.private),
 ]


### PR DESCRIPTION
- deleteEvent() :  Only admins/delegators are allowed to delete events. 
- blockUsers()  : Created new url endpoint where pass in usernames/google-api-auth-usernames. This endpoint will not allow specific users from joining/rejoining organizations, and will not be able to see any events from that club; past or future. 
- Passcode functionality : Allowing private/public organizations. Private organizations require a passcode to join and public requires no passcode, essentially an empty string. 
- Organization Description : When creating organizations, users can pass in a string describing their organizations. Will be implemented more next half of the sprint. 
- Include club name in getCalendarInfo() : First element of getCalendarInfo() dictionary will be club name corresponding to the hash. Look at Sprint 4 Planning for an example. 